### PR TITLE
Getting diagnostic alerts from the lidar during run

### DIFF
--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -100,7 +100,13 @@ bool read_imu_packet(const client& cli, uint8_t* buf, const packet_format& pf);
  */
 std::string get_metadata(client& cli, int timeout_sec = 30);
 
-std::string get_alerts(std::string hostname, int timeout_sec = 1);
+/**
+ * Get diagnostic alerts from the sensor.
+ *
+ * @param hostname hostname of the sensor
+ * @return a text blob of the alerts
+ */
+std::string get_alerts(std::string hostname);
 
 }  // namespace sensor
 }  // namespace ouster

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -100,7 +100,7 @@ bool read_imu_packet(const client& cli, uint8_t* buf, const packet_format& pf);
  */
 std::string get_metadata(client& cli, int timeout_sec = 30);
 
-std::string get_alerts(client& cli, int timeout_sec = 1);
+std::string get_alerts(std::string hostname, int timeout_sec = 1);
 
 }  // namespace sensor
 }  // namespace ouster

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -100,5 +100,7 @@ bool read_imu_packet(const client& cli, uint8_t* buf, const packet_format& pf);
  */
 std::string get_metadata(client& cli, int timeout_sec = 30);
 
+std::string get_alerts(client& cli, int timeout_sec = 1);
+
 }  // namespace sensor
 }  // namespace ouster

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -21,400 +21,413 @@
 #include "ouster/impl/netcompat.h"
 #include "ouster/types.h"
 
-namespace ouster {
-namespace sensor {
+namespace ouster
+{
+namespace sensor
+{
 
 namespace chrono = std::chrono;
 
-struct client {
-    SOCKET lidar_fd;
-    SOCKET imu_fd;
-    std::string hostname;
-    Json::Value meta;
-    ~client() {
-        impl::socket_close(lidar_fd);
-        impl::socket_close(imu_fd);
-    }
+struct client
+{
+  SOCKET      lidar_fd;
+  SOCKET      imu_fd;
+  std::string hostname;
+  Json::Value meta;
+  ~client() {
+    impl::socket_close(lidar_fd);
+    impl::socket_close(imu_fd);
+  }
 };
 
-namespace {
+namespace
+{
 
 // default udp receive buffer size on windows is very low -- use 256K
 const int RCVBUF_SIZE = 256 * 1024;
 
 int32_t get_sock_port(SOCKET sock_fd) {
-    struct sockaddr_storage ss;
-    socklen_t addrlen = sizeof ss;
+  struct sockaddr_storage ss;
+  socklen_t               addrlen = sizeof ss;
 
-    if (!impl::socket_valid(
-            getsockname(sock_fd, (struct sockaddr*)&ss, &addrlen))) {
-        std::cerr << "udp getsockname(): " << impl::socket_get_error()
-                  << std::endl;
-        return SOCKET_ERROR;
-    }
+  if (!impl::socket_valid(getsockname(sock_fd, (struct sockaddr*)&ss, &addrlen))) {
+    std::cerr << "udp getsockname(): " << impl::socket_get_error() << std::endl;
+    return SOCKET_ERROR;
+  }
 
-    if (ss.ss_family == AF_INET)
-        return ntohs(((struct sockaddr_in*)&ss)->sin_port);
-    else if (ss.ss_family == AF_INET6)
-        return ntohs(((struct sockaddr_in6*)&ss)->sin6_port);
-    else
-        return SOCKET_ERROR;
+  if (ss.ss_family == AF_INET)
+    return ntohs(((struct sockaddr_in*)&ss)->sin_port);
+  else if (ss.ss_family == AF_INET6)
+    return ntohs(((struct sockaddr_in6*)&ss)->sin6_port);
+  else
+    return SOCKET_ERROR;
 }
 
 SOCKET udp_data_socket(int port) {
-    struct addrinfo hints, *info_start, *ai;
+  struct addrinfo hints, *info_start, *ai;
 
-    memset(&hints, 0, sizeof hints);
-    hints.ai_family = AF_INET6;
-    hints.ai_socktype = SOCK_DGRAM;
-    hints.ai_flags = AI_PASSIVE;
+  memset(&hints, 0, sizeof hints);
+  hints.ai_family   = AF_INET6;
+  hints.ai_socktype = SOCK_DGRAM;
+  hints.ai_flags    = AI_PASSIVE;
 
-    auto port_s = std::to_string(port);
+  auto port_s = std::to_string(port);
 
-    int ret = getaddrinfo(NULL, port_s.c_str(), &hints, &info_start);
-    if (ret != 0) {
-        std::cerr << "getaddrinfo(): " << gai_strerror(ret) << std::endl;
-        return SOCKET_ERROR;
-    }
-    if (info_start == NULL) {
-        std::cerr << "getaddrinfo: empty result" << std::endl;
-        return SOCKET_ERROR;
-    }
+  int ret = getaddrinfo(NULL, port_s.c_str(), &hints, &info_start);
+  if (ret != 0) {
+    std::cerr << "getaddrinfo(): " << gai_strerror(ret) << std::endl;
+    return SOCKET_ERROR;
+  }
+  if (info_start == NULL) {
+    std::cerr << "getaddrinfo: empty result" << std::endl;
+    return SOCKET_ERROR;
+  }
 
-    SOCKET sock_fd;
-    for (ai = info_start; ai != NULL; ai = ai->ai_next) {
-        sock_fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
-        if (!impl::socket_valid(sock_fd)) {
-            std::cerr << "udp socket(): " << impl::socket_get_error()
-                      << std::endl;
-            continue;
-        }
-
-        int off = 0;
-        if (setsockopt(sock_fd, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&off,
-                       sizeof(off))) {
-            std::cerr << "udp setsockopt(): " << impl::socket_get_error()
-                      << std::endl;
-            impl::socket_close(sock_fd);
-            return SOCKET_ERROR;
-        }
-
-        if (bind(sock_fd, ai->ai_addr, (socklen_t)ai->ai_addrlen)) {
-            impl::socket_close(sock_fd);
-            std::cerr << "udp bind(): " << impl::socket_get_error()
-                      << std::endl;
-            continue;
-        }
-
-        break;
+  SOCKET sock_fd;
+  for (ai = info_start; ai != NULL; ai = ai->ai_next) {
+    sock_fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+    if (!impl::socket_valid(sock_fd)) {
+      std::cerr << "udp socket(): " << impl::socket_get_error() << std::endl;
+      continue;
     }
 
-    freeaddrinfo(info_start);
-    if (ai == NULL) {
-        impl::socket_close(sock_fd);
-        return SOCKET_ERROR;
+    int off = 0;
+    if (setsockopt(sock_fd, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&off, sizeof(off))) {
+      std::cerr << "udp setsockopt(): " << impl::socket_get_error() << std::endl;
+      impl::socket_close(sock_fd);
+      return SOCKET_ERROR;
     }
 
-    if (!impl::socket_valid(impl::socket_set_non_blocking(sock_fd))) {
-        std::cerr << "udp fcntl(): " << impl::socket_get_error() << std::endl;
-        impl::socket_close(sock_fd);
-        return SOCKET_ERROR;
+    if (bind(sock_fd, ai->ai_addr, (socklen_t)ai->ai_addrlen)) {
+      impl::socket_close(sock_fd);
+      std::cerr << "udp bind(): " << impl::socket_get_error() << std::endl;
+      continue;
     }
 
-    if (!impl::socket_valid(setsockopt(sock_fd, SOL_SOCKET, SO_RCVBUF,
-                                       (char*)&RCVBUF_SIZE,
-                                       sizeof(RCVBUF_SIZE)))) {
-        std::cerr << "udp setsockopt(): " << impl::socket_get_error()
-                  << std::endl;
-        impl::socket_close(sock_fd);
-        return SOCKET_ERROR;
-    }
+    break;
+  }
 
-    return sock_fd;
+  freeaddrinfo(info_start);
+  if (ai == NULL) {
+    impl::socket_close(sock_fd);
+    return SOCKET_ERROR;
+  }
+
+  if (!impl::socket_valid(impl::socket_set_non_blocking(sock_fd))) {
+    std::cerr << "udp fcntl(): " << impl::socket_get_error() << std::endl;
+    impl::socket_close(sock_fd);
+    return SOCKET_ERROR;
+  }
+
+  if (!impl::socket_valid(setsockopt(sock_fd, SOL_SOCKET, SO_RCVBUF, (char*)&RCVBUF_SIZE, sizeof(RCVBUF_SIZE)))) {
+    std::cerr << "udp setsockopt(): " << impl::socket_get_error() << std::endl;
+    impl::socket_close(sock_fd);
+    return SOCKET_ERROR;
+  }
+
+  return sock_fd;
 }
 
 SOCKET cfg_socket(const char* addr) {
-    struct addrinfo hints, *info_start, *ai;
+  struct addrinfo hints, *info_start, *ai;
 
-    memset(&hints, 0, sizeof hints);
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
+  memset(&hints, 0, sizeof hints);
+  hints.ai_family   = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
 
-    int ret = getaddrinfo(addr, "7501", &hints, &info_start);
-    if (ret != 0) {
-        std::cerr << "getaddrinfo: " << gai_strerror(ret) << std::endl;
-        return SOCKET_ERROR;
-    }
-    if (info_start == NULL) {
-        std::cerr << "getaddrinfo: empty result" << std::endl;
-        return SOCKET_ERROR;
-    }
+  int ret = getaddrinfo(addr, "7501", &hints, &info_start);
+  if (ret != 0) {
+    std::cerr << "getaddrinfo: " << gai_strerror(ret) << std::endl;
+    return SOCKET_ERROR;
+  }
+  if (info_start == NULL) {
+    std::cerr << "getaddrinfo: empty result" << std::endl;
+    return SOCKET_ERROR;
+  }
 
-    SOCKET sock_fd;
-    for (ai = info_start; ai != NULL; ai = ai->ai_next) {
-        sock_fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
-        if (!impl::socket_valid(sock_fd)) {
-            std::cerr << "socket: " << impl::socket_get_error() << std::endl;
-            continue;
-        }
-
-        if (connect(sock_fd, ai->ai_addr, (socklen_t)ai->ai_addrlen) < 0) {
-            impl::socket_close(sock_fd);
-            continue;
-        }
-
-        break;
+  SOCKET sock_fd;
+  for (ai = info_start; ai != NULL; ai = ai->ai_next) {
+    sock_fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+    if (!impl::socket_valid(sock_fd)) {
+      std::cerr << "socket: " << impl::socket_get_error() << std::endl;
+      continue;
     }
 
-    freeaddrinfo(info_start);
-    if (ai == NULL) {
-        return SOCKET_ERROR;
+    if (connect(sock_fd, ai->ai_addr, (socklen_t)ai->ai_addrlen) < 0) {
+      impl::socket_close(sock_fd);
+      continue;
     }
 
-    return sock_fd;
+    break;
+  }
+
+  freeaddrinfo(info_start);
+  if (ai == NULL) {
+    return SOCKET_ERROR;
+  }
+
+  return sock_fd;
 }
 
-bool do_tcp_cmd(SOCKET sock_fd, const std::vector<std::string>& cmd_tokens,
-                std::string& res) {
-    const size_t max_res_len = 16 * 1024;
-    auto read_buf = std::unique_ptr<char[]>{new char[max_res_len + 1]};
+bool do_tcp_cmd(SOCKET sock_fd, const std::vector<std::string>& cmd_tokens, std::string& res) {
+  const size_t max_res_len = 16 * 1024;
+  auto         read_buf    = std::unique_ptr<char[]>{new char[max_res_len + 1]};
 
-    std::stringstream ss;
-    for (const auto& token : cmd_tokens) ss << token << " ";
-    ss << "\n";
-    std::string cmd = ss.str();
+  std::stringstream ss;
+  for (const auto& token : cmd_tokens)
+    ss << token << " ";
+  ss << "\n";
+  std::string cmd = ss.str();
 
-    ssize_t len = send(sock_fd, cmd.c_str(), cmd.length(), 0);
-    if (len != (ssize_t)cmd.length()) {
-        return false;
+  ssize_t len = send(sock_fd, cmd.c_str(), cmd.length(), 0);
+  if (len != (ssize_t)cmd.length()) {
+    return false;
+  }
+
+  // need to synchronize with server by reading response
+  std::stringstream read_ss;
+  do {
+    len = recv(sock_fd, read_buf.get(), max_res_len, 0);
+    if (len < 0) {
+      return false;
     }
+    read_buf.get()[len] = '\0';
+    read_ss << read_buf.get();
+  } while (len > 0 && read_buf.get()[len - 1] != '\n');
 
-    // need to synchronize with server by reading response
-    std::stringstream read_ss;
-    do {
-        len = recv(sock_fd, read_buf.get(), max_res_len, 0);
-        if (len < 0) {
-            return false;
-        }
-        read_buf.get()[len] = '\0';
-        read_ss << read_buf.get();
-    } while (len > 0 && read_buf.get()[len - 1] != '\n');
+  res = read_ss.str();
+  res.erase(res.find_last_not_of(" \r\n\t") + 1);
 
-    res = read_ss.str();
-    res.erase(res.find_last_not_of(" \r\n\t") + 1);
-
-    return true;
+  return true;
 }
 
 void update_json_obj(Json::Value& dst, const Json::Value& src) {
-    const std::vector<std::string>& members = src.getMemberNames();
-    for (const auto& key : members) {
-        dst[key] = src[key];
-    }
+  const std::vector<std::string>& members = src.getMemberNames();
+  for (const auto& key : members) {
+    dst[key] = src[key];
+  }
 }
 
 bool collect_metadata(client& cli, SOCKET sock_fd, chrono::seconds timeout) {
-    Json::CharReaderBuilder builder{};
-    auto reader = std::unique_ptr<Json::CharReader>{builder.newCharReader()};
-    Json::Value root{};
-    std::string errors{};
+  Json::CharReaderBuilder builder{};
+  auto                    reader = std::unique_ptr<Json::CharReader>{builder.newCharReader()};
+  Json::Value             root{};
+  std::string             errors{};
 
-    std::string res;
-    bool success = true;
+  std::string res;
+  bool        success = true;
 
-    auto timeout_time = chrono::steady_clock::now() + timeout;
+  auto timeout_time = chrono::steady_clock::now() + timeout;
 
-    do {
-        success &= do_tcp_cmd(sock_fd, {"get_sensor_info"}, res);
-        success &=
-            reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
+  do {
+    success &= do_tcp_cmd(sock_fd, {"get_sensor_info"}, res);
+    success &= reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
 
-        if (chrono::steady_clock::now() >= timeout_time) return false;
-        std::this_thread::sleep_for(chrono::seconds(1));
-    } while (success && root["status"].asString() == "INITIALIZING");
+    if (chrono::steady_clock::now() >= timeout_time)
+      return false;
+    std::this_thread::sleep_for(chrono::seconds(1));
+  } while (success && root["status"].asString() == "INITIALIZING");
 
-    update_json_obj(cli.meta, root);
-    success &= cli.meta["status"].asString() == "RUNNING";
+  update_json_obj(cli.meta, root);
+  success &= cli.meta["status"].asString() == "RUNNING";
 
-    success &= do_tcp_cmd(sock_fd, {"get_beam_intrinsics"}, res);
-    success &=
-        reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
-    update_json_obj(cli.meta, root);
+  success &= do_tcp_cmd(sock_fd, {"get_beam_intrinsics"}, res);
+  success &= reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
+  update_json_obj(cli.meta, root);
 
-    success &= do_tcp_cmd(sock_fd, {"get_imu_intrinsics"}, res);
-    success &=
-        reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
-    update_json_obj(cli.meta, root);
+  success &= do_tcp_cmd(sock_fd, {"get_imu_intrinsics"}, res);
+  success &= reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
+  update_json_obj(cli.meta, root);
 
-    success &= do_tcp_cmd(sock_fd, {"get_lidar_intrinsics"}, res);
-    success &=
-        reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
-    update_json_obj(cli.meta, root);
+  success &= do_tcp_cmd(sock_fd, {"get_lidar_intrinsics"}, res);
+  success &= reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
+  update_json_obj(cli.meta, root);
 
-    // try to query data format
-    bool got_format = true;
-    got_format &= do_tcp_cmd(sock_fd, {"get_lidar_data_format"}, res);
-    got_format &=
-        reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
-    if (got_format) cli.meta["data_format"] = root;
+  // try to query data format
+  bool got_format = true;
+  got_format &= do_tcp_cmd(sock_fd, {"get_lidar_data_format"}, res);
+  got_format &= reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
+  if (got_format)
+    cli.meta["data_format"] = root;
 
-    // get lidar mode
-    success &= do_tcp_cmd(sock_fd, {"get_config_param", "active"}, res);
-    success &=
-        reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
+  // get lidar mode
+  success &= do_tcp_cmd(sock_fd, {"get_config_param", "active"}, res);
+  success &= reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
 
-    // merge extra info into metadata
-    cli.meta["hostname"] = cli.hostname;
-    cli.meta["lidar_mode"] = root["lidar_mode"];
-    cli.meta["client_version"] = ouster::CLIENT_VERSION;
+  // merge extra info into metadata
+  cli.meta["hostname"]       = cli.hostname;
+  cli.meta["lidar_mode"]     = root["lidar_mode"];
+  cli.meta["client_version"] = ouster::CLIENT_VERSION;
 
-    cli.meta["json_calibration_version"] = FW_2_0;
+  cli.meta["json_calibration_version"] = FW_2_0;
 
-    return success;
+  return success;
 }
 }  // namespace
 
 std::string get_metadata(client& cli, int timeout_sec) {
-    if (!cli.meta) {
-        SOCKET sock_fd = cfg_socket(cli.hostname.c_str());
-        if (sock_fd < 0) return "";
+  if (!cli.meta) {
+    SOCKET sock_fd = cfg_socket(cli.hostname.c_str());
+    if (sock_fd < 0)
+      return "";
 
-        bool success =
-            collect_metadata(cli, sock_fd, chrono::seconds{timeout_sec});
-
-        impl::socket_close(sock_fd);
-
-        if (!success) return "";
-    }
-
-    Json::StreamWriterBuilder builder;
-    builder["enableYAMLCompatibility"] = true;
-    builder["precision"] = 6;
-    builder["indentation"] = "    ";
-    return Json::writeString(builder, cli.meta);
-}
-
-std::shared_ptr<client> init_client(const std::string& hostname, int lidar_port,
-                                    int imu_port) {
-    auto cli = std::make_shared<client>();
-    cli->hostname = hostname;
-
-    cli->lidar_fd = udp_data_socket(lidar_port);
-    cli->imu_fd = udp_data_socket(imu_port);
-
-    if (!impl::socket_valid(cli->lidar_fd) || !impl::socket_valid(cli->imu_fd))
-        return std::shared_ptr<client>();
-
-    return cli;
-}
-
-std::shared_ptr<client> init_client(const std::string& hostname,
-                                    const std::string& udp_dest_host,
-                                    lidar_mode mode, timestamp_mode ts_mode,
-                                    int lidar_port, int imu_port,
-                                    int timeout_sec) {
-    auto cli = init_client(hostname, lidar_port, imu_port);
-    if (!cli) return std::shared_ptr<client>();
-
-    // update requested ports to actual bound ports
-    lidar_port = get_sock_port(cli->lidar_fd);
-    imu_port = get_sock_port(cli->imu_fd);
-    if (!impl::socket_valid(lidar_port) || !impl::socket_valid(imu_port))
-        return std::shared_ptr<client>();
-
-    SOCKET sock_fd = cfg_socket(hostname.c_str());
-    if (!impl::socket_valid(sock_fd)) return std::shared_ptr<client>();
-
-    std::string res;
-    bool success = true;
-
-    success &=
-        do_tcp_cmd(sock_fd, {"set_config_param", "udp_ip", udp_dest_host}, res);
-    success &= res == "set_config_param";
-
-    success &= do_tcp_cmd(
-        sock_fd,
-        {"set_config_param", "udp_port_lidar", std::to_string(lidar_port)},
-        res);
-    success &= res == "set_config_param";
-
-    success &= do_tcp_cmd(
-        sock_fd, {"set_config_param", "udp_port_imu", std::to_string(imu_port)},
-        res);
-    success &= res == "set_config_param";
-
-    // if specified (not UNSPEC), set the lidar and timestamp modes
-    if (mode) {
-        success &= do_tcp_cmd(
-            sock_fd, {"set_config_param", "lidar_mode", to_string(mode)}, res);
-        success &= res == "set_config_param";
-    }
-
-    if (ts_mode) {
-        success &= do_tcp_cmd(
-            sock_fd, {"set_config_param", "timestamp_mode", to_string(ts_mode)},
-            res);
-        success &= res == "set_config_param";
-    }
-
-    success &= do_tcp_cmd(sock_fd, {"reinitialize"}, res);
-    success &= res == "reinitialize";
-
-    success &= collect_metadata(*cli, sock_fd, chrono::seconds{timeout_sec});
+    bool success = collect_metadata(cli, sock_fd, chrono::seconds{timeout_sec});
 
     impl::socket_close(sock_fd);
 
-    return success ? cli : std::shared_ptr<client>();
+    if (!success)
+      return "";
+  }
+
+  Json::StreamWriterBuilder builder;
+  builder["enableYAMLCompatibility"] = true;
+  builder["precision"]               = 6;
+  builder["indentation"]             = "    ";
+  return Json::writeString(builder, cli.meta);
+}
+
+std::string get_alerts(client& cli, int timeout_sec) {
+  SOCKET sock_fd = cfg_socket(cli.hostname.c_str());
+  if (sock_fd < 0)
+    return "";
+
+  /* Json::CharReaderBuilder builder{}; */
+  /* auto                    reader = std::unique_ptr<Json::CharReader>{builder.newCharReader()}; */
+  /* Json::Value             root{}; */
+  /* std::string             errors{}; */
+
+  /* bool success = collect_metadata(cli, sock_fd, chrono::seconds{timeout_sec}); */
+  std::string res;
+  bool        success = true;
+  success &= do_tcp_cmd(sock_fd, {"get_alerts"}, res);
+  /* success &= reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL); */
+
+  /* } while (success && root["status"].asString() == "INITIALIZING"); */
+
+  impl::socket_close(sock_fd);
+
+  if (!success)
+    return "";
+
+  /* Json::StreamWriterBuilder builder; */
+  /* builder["enableYAMLCompatibility"] = true; */
+  /* builder["precision"]               = 6; */
+  /* builder["indentation"]             = "    "; */
+  /* return Json::writeString(builder, cli.meta); */
+  return res;
+}
+
+std::shared_ptr<client> init_client(const std::string& hostname, int lidar_port, int imu_port) {
+  auto cli      = std::make_shared<client>();
+  cli->hostname = hostname;
+
+  cli->lidar_fd = udp_data_socket(lidar_port);
+  cli->imu_fd   = udp_data_socket(imu_port);
+
+  if (!impl::socket_valid(cli->lidar_fd) || !impl::socket_valid(cli->imu_fd))
+    return std::shared_ptr<client>();
+
+  return cli;
+}
+
+std::shared_ptr<client> init_client(const std::string& hostname, const std::string& udp_dest_host, lidar_mode mode, timestamp_mode ts_mode, int lidar_port,
+                                    int imu_port, int timeout_sec) {
+  auto cli = init_client(hostname, lidar_port, imu_port);
+  if (!cli)
+    return std::shared_ptr<client>();
+
+  // update requested ports to actual bound ports
+  lidar_port = get_sock_port(cli->lidar_fd);
+  imu_port   = get_sock_port(cli->imu_fd);
+  if (!impl::socket_valid(lidar_port) || !impl::socket_valid(imu_port))
+    return std::shared_ptr<client>();
+
+  SOCKET sock_fd = cfg_socket(hostname.c_str());
+  if (!impl::socket_valid(sock_fd))
+    return std::shared_ptr<client>();
+
+  std::string res;
+  bool        success = true;
+
+  success &= do_tcp_cmd(sock_fd, {"set_config_param", "udp_ip", udp_dest_host}, res);
+  success &= res == "set_config_param";
+
+  success &= do_tcp_cmd(sock_fd, {"set_config_param", "udp_port_lidar", std::to_string(lidar_port)}, res);
+  success &= res == "set_config_param";
+
+  success &= do_tcp_cmd(sock_fd, {"set_config_param", "udp_port_imu", std::to_string(imu_port)}, res);
+  success &= res == "set_config_param";
+
+  // if specified (not UNSPEC), set the lidar and timestamp modes
+  if (mode) {
+    success &= do_tcp_cmd(sock_fd, {"set_config_param", "lidar_mode", to_string(mode)}, res);
+    success &= res == "set_config_param";
+  }
+
+  if (ts_mode) {
+    success &= do_tcp_cmd(sock_fd, {"set_config_param", "timestamp_mode", to_string(ts_mode)}, res);
+    success &= res == "set_config_param";
+  }
+
+  success &= do_tcp_cmd(sock_fd, {"reinitialize"}, res);
+  success &= res == "reinitialize";
+
+  success &= collect_metadata(*cli, sock_fd, chrono::seconds{timeout_sec});
+
+  impl::socket_close(sock_fd);
+
+  return success ? cli : std::shared_ptr<client>();
 }
 
 client_state poll_client(const client& c, const int timeout_sec) {
-    fd_set rfds;
-    FD_ZERO(&rfds);
-    FD_SET(c.lidar_fd, &rfds);
-    FD_SET(c.imu_fd, &rfds);
+  fd_set rfds;
+  FD_ZERO(&rfds);
+  FD_SET(c.lidar_fd, &rfds);
+  FD_SET(c.imu_fd, &rfds);
 
-    timeval tv;
-    tv.tv_sec = timeout_sec;
-    tv.tv_usec = 0;
+  timeval tv;
+  tv.tv_sec  = timeout_sec;
+  tv.tv_usec = 0;
 
-    SOCKET max_fd = std::max(c.lidar_fd, c.imu_fd);
+  SOCKET max_fd = std::max(c.lidar_fd, c.imu_fd);
 
-    SOCKET retval = select((int)max_fd + 1, &rfds, NULL, NULL, &tv);
+  SOCKET retval = select((int)max_fd + 1, &rfds, NULL, NULL, &tv);
 
-    client_state res = client_state(0);
+  client_state res = client_state(0);
 
-    if (!impl::socket_valid(retval) && impl::socket_exit()) {
-        res = EXIT;
-    } else if (!impl::socket_valid(retval)) {
-        std::cerr << "select: " << impl::socket_get_error() << std::endl;
-        res = client_state(res | CLIENT_ERROR);
-    } else if (retval) {
-        if (FD_ISSET(c.lidar_fd, &rfds)) res = client_state(res | LIDAR_DATA);
-        if (FD_ISSET(c.imu_fd, &rfds)) res = client_state(res | IMU_DATA);
-    }
+  if (!impl::socket_valid(retval) && impl::socket_exit()) {
+    res = EXIT;
+  } else if (!impl::socket_valid(retval)) {
+    std::cerr << "select: " << impl::socket_get_error() << std::endl;
+    res = client_state(res | CLIENT_ERROR);
+  } else if (retval) {
+    if (FD_ISSET(c.lidar_fd, &rfds))
+      res = client_state(res | LIDAR_DATA);
+    if (FD_ISSET(c.imu_fd, &rfds))
+      res = client_state(res | IMU_DATA);
+  }
 
-    return res;
+  return res;
 }
 
 static bool recv_fixed(SOCKET fd, void* buf, int64_t len) {
-    int64_t n = recv(fd, (char*)buf, len + 1, 0);
-    if (n == len) {
-        return true;
-    } else if (n == -1) {
-        std::cerr << "recvfrom: " << impl::socket_get_error() << std::endl;
-    } else {
-        std::cerr << "Unexpected udp packet length: " << n << std::endl;
-    }
-    return false;
+  int64_t n = recv(fd, (char*)buf, len + 1, 0);
+  if (n == len) {
+    return true;
+  } else if (n == -1) {
+    std::cerr << "recvfrom: " << impl::socket_get_error() << std::endl;
+  } else {
+    std::cerr << "Unexpected udp packet length: " << n << std::endl;
+  }
+  return false;
 }
 
-bool read_lidar_packet(const client& cli, uint8_t* buf,
-                       const packet_format& pf) {
-    return recv_fixed(cli.lidar_fd, buf, pf.lidar_packet_size);
+bool read_lidar_packet(const client& cli, uint8_t* buf, const packet_format& pf) {
+  return recv_fixed(cli.lidar_fd, buf, pf.lidar_packet_size);
 }
 
 bool read_imu_packet(const client& cli, uint8_t* buf, const packet_format& pf) {
-    return recv_fixed(cli.imu_fd, buf, pf.imu_packet_size);
+  return recv_fixed(cli.imu_fd, buf, pf.imu_packet_size);
 }
 
 }  // namespace sensor

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -292,16 +292,30 @@ std::string get_alerts(std::string hostname, int timeout_sec) {
   if (sock_fd < 0)
     return "";
 
-  /* Json::CharReaderBuilder builder{}; */
-  /* auto                    reader = std::unique_ptr<Json::CharReader>{builder.newCharReader()}; */
-  /* Json::Value             root{}; */
-  /* std::string             errors{}; */
+  Json::CharReaderBuilder builder{};
+  auto                    reader = std::unique_ptr<Json::CharReader>{builder.newCharReader()};
+  Json::Value             root{};
+  std::string             errors{};
 
   /* bool success = collect_metadata(cli, sock_fd, chrono::seconds{timeout_sec}); */
   std::string res;
   bool        success = true;
   success &= do_tcp_cmd(sock_fd, {"get_alerts"}, res);
-  /* success &= reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL); */
+
+  success &= reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
+  Json::Value log = root["log"];
+
+  for (const auto& alert : log) {
+    if (alert["active"].asString() == "true"){
+      std::cout << alert << std::endl;
+    }
+  }
+  /* std::cout << root["log"] << std::endl; */
+  /* const std::vector<std::string>& members = root.getMemberNames(); */
+  /* for (const auto& key : members) { */
+    /* dst[key] = src[key]; */
+    /* std::cout << key.c_str() << std::endl; */
+  /* } */
 
   /* } while (success && root["status"].asString() == "INITIALIZING"); */
 

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -286,8 +286,9 @@ std::string get_metadata(client& cli, int timeout_sec) {
   return Json::writeString(builder, cli.meta);
 }
 
-std::string get_alerts(client& cli, int timeout_sec) {
-  SOCKET sock_fd = cfg_socket(cli.hostname.c_str());
+/* std::string get_alerts(client& cli, int timeout_sec) { */
+std::string get_alerts(std::string hostname, int timeout_sec) {
+  SOCKET sock_fd = cfg_socket(hostname.c_str());
   if (sock_fd < 0)
     return "";
 

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -292,24 +292,24 @@ std::string get_alerts(std::string hostname, int timeout_sec) {
   if (sock_fd < 0)
     return "";
 
-  Json::CharReaderBuilder builder{};
-  auto                    reader = std::unique_ptr<Json::CharReader>{builder.newCharReader()};
-  Json::Value             root{};
-  std::string             errors{};
+  /* Json::CharReaderBuilder builder{}; */
+  /* auto                    reader = std::unique_ptr<Json::CharReader>{builder.newCharReader()}; */
+  /* Json::Value             root{}; */
+  /* std::string             errors{}; */
 
   /* bool success = collect_metadata(cli, sock_fd, chrono::seconds{timeout_sec}); */
   std::string res;
   bool        success = true;
   success &= do_tcp_cmd(sock_fd, {"get_alerts"}, res);
 
-  success &= reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL);
-  Json::Value log = root["log"];
+  /* success &= reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL); */
+  /* Json::Value log = root["log"]; */
 
-  for (const auto& alert : log) {
-    if (alert["active"].asString() == "true"){
-      std::cout << alert << std::endl;
-    }
-  }
+  /* for (const auto& alert : log) { */
+  /*   if (alert["active"].asString() == "true"){ */
+  /*     std::cout << alert << std::endl; */
+  /*   } */
+  /* } */
   /* std::cout << root["log"] << std::endl; */
   /* const std::vector<std::string>& members = root.getMemberNames(); */
   /* for (const auto& key : members) { */

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -286,49 +286,20 @@ std::string get_metadata(client& cli, int timeout_sec) {
   return Json::writeString(builder, cli.meta);
 }
 
-/* std::string get_alerts(client& cli, int timeout_sec) { */
-std::string get_alerts(std::string hostname, int timeout_sec) {
+std::string get_alerts(std::string hostname) {
   SOCKET sock_fd = cfg_socket(hostname.c_str());
   if (sock_fd < 0)
     return "";
 
-  /* Json::CharReaderBuilder builder{}; */
-  /* auto                    reader = std::unique_ptr<Json::CharReader>{builder.newCharReader()}; */
-  /* Json::Value             root{}; */
-  /* std::string             errors{}; */
-
-  /* bool success = collect_metadata(cli, sock_fd, chrono::seconds{timeout_sec}); */
   std::string res;
   bool        success = true;
   success &= do_tcp_cmd(sock_fd, {"get_alerts"}, res);
-
-  /* success &= reader->parse(res.c_str(), res.c_str() + res.size(), &root, NULL); */
-  /* Json::Value log = root["log"]; */
-
-  /* for (const auto& alert : log) { */
-  /*   if (alert["active"].asString() == "true"){ */
-  /*     std::cout << alert << std::endl; */
-  /*   } */
-  /* } */
-  /* std::cout << root["log"] << std::endl; */
-  /* const std::vector<std::string>& members = root.getMemberNames(); */
-  /* for (const auto& key : members) { */
-    /* dst[key] = src[key]; */
-    /* std::cout << key.c_str() << std::endl; */
-  /* } */
-
-  /* } while (success && root["status"].asString() == "INITIALIZING"); */
 
   impl::socket_close(sock_fd);
 
   if (!success)
     return "";
 
-  /* Json::StreamWriterBuilder builder; */
-  /* builder["enableYAMLCompatibility"] = true; */
-  /* builder["precision"]               = 6; */
-  /* builder["indentation"]             = "    "; */
-  /* return Json::writeString(builder, cli.meta); */
   return res;
 }
 

--- a/ouster_ros/CMakeLists.txt
+++ b/ouster_ros/CMakeLists.txt
@@ -85,7 +85,7 @@ catkin_package(
   sensor_msgs
   geometry_msgs
   DEPENDS
-  jsoncpp_lib EIGEN3 GLFW3 GLEW)
+  EIGEN3 GLFW3 GLEW)
 
 # ==== Libraries ====
 # Build static libraries and bundle them into ouster_ros using the `--whole-archive` flag. This is

--- a/ouster_ros/CMakeLists.txt
+++ b/ouster_ros/CMakeLists.txt
@@ -23,6 +23,7 @@ endif()
 find_package(Eigen3 REQUIRED)
 find_package(GLEW REQUIRED)
 find_package(glfw3 REQUIRED)
+find_package(jsoncpp REQUIRED)
 
 find_package(
   catkin REQUIRED
@@ -84,7 +85,7 @@ catkin_package(
   sensor_msgs
   geometry_msgs
   DEPENDS
-  EIGEN3 GLFW3 GLEW)
+  jsoncpp_lib EIGEN3 GLFW3 GLEW)
 
 # ==== Libraries ====
 # Build static libraries and bundle them into ouster_ros using the `--whole-archive` flag. This is
@@ -110,7 +111,7 @@ target_link_libraries(OusterCloudNodelet ouster_ros ${catkin_LIBRARIES})
 add_dependencies(OusterCloudNodelet ${PROJECT_NAME}_gencpp)
 
 add_library(OusterNodelet src/os_nodelet.cpp)
-target_link_libraries(OusterNodelet ouster_ros ${catkin_LIBRARIES})
+target_link_libraries(OusterNodelet ouster_ros ${catkin_LIBRARIES} jsoncpp_lib)
 add_dependencies(OusterNodelet ${PROJECT_NAME}_gencpp)
 
 add_library(OusterImgNodelet src/img_nodelet.cpp)

--- a/ouster_ros/launch/uav.launch
+++ b/ouster_ros/launch/uav.launch
@@ -42,6 +42,7 @@
       <remap from="~lidar_packets" to="~lidar_packets" />
       <remap from="~imu_packets" to="~imu_packets" />
       <remap from="~sensor_info" to="~sensor_info" />
+      <remap from="~uav_status" to="mrs_uav_status/display_string" />
 
     </node>
 

--- a/ouster_ros/src/os_nodelet.cpp
+++ b/ouster_ros/src/os_nodelet.cpp
@@ -251,6 +251,9 @@ int OusterNodelet::run() {
     ouster_info.beam_azimuth_angles            = info.beam_azimuth_angles;
     ouster_info.beam_altitude_angles           = info.beam_altitude_angles;
     ouster_info.lidar_origin_to_beam_origin_mm = info.lidar_origin_to_beam_origin_mm;
+    ouster_info.pixels_per_column = info.format.pixels_per_column;
+    ouster_info.columns_per_frame = info.format.columns_per_frame;
+    ouster_info.pixel_shift_by_row = info.format.pixel_shift_by_row;
 
     info.imu_to_sensor_transform.transposeInPlace();
     info.lidar_to_sensor_transform.transposeInPlace();

--- a/ouster_ros/src/os_nodelet.cpp
+++ b/ouster_ros/src/os_nodelet.cpp
@@ -312,6 +312,8 @@ int OusterNodelet::run() {
       }
       if (state == sensor::TIMEOUT) {
         ROS_WARN("[OusterNodelet]: poll_client: TIMEOUT");
+        std::string alerts = sensor::get_alerts(*cli, 1);
+        ROS_WARN("[OusterNodelet]: alerts: %s", alerts.c_str());
       }
 
 

--- a/ouster_ros/src/os_nodelet.cpp
+++ b/ouster_ros/src/os_nodelet.cpp
@@ -9,6 +9,7 @@
  * imu_port: port to which the sensor should send imu data
  */
 
+#include <chrono>
 #include <ros/console.h>
 #include <ros/init.h>
 #include <ros/ros.h>
@@ -336,7 +337,8 @@ int OusterNodelet::run_alerts_loop() {
   while (ros::ok() && is_running_) {
     std::string alerts = sensor::get_alerts(hostname_, 1);
     ROS_WARN("[OusterNodelet]: alerts: %s", alerts.c_str());
-    std::this_thread::sleep_for(std::chrono::seconds(5));
+    /* std::this_thread::sleep_for(std::chrono::milliseconds(100)); */
+    std::this_thread::sleep_for(std::chrono::seconds(1));
   }
 
   return EXIT_SUCCESS;

--- a/ouster_ros/src/os_nodelet.cpp
+++ b/ouster_ros/src/os_nodelet.cpp
@@ -140,7 +140,7 @@ int OusterNodelet::run() {
 
   sensor_info_publisher_       = nh.advertise<mrs_msgs::OusterInfo>("sensor_info", 1, true);
   alerts_publisher_            = nh.advertise<std_msgs::String>("alerts", 1, true);
-  alerts_publisher_uav_status_ = nh.advertise<std_msgs::String>("uav_status", 1, true);
+  alerts_publisher_uav_status_ = nh.advertise<std_msgs::String>("uav_status", 1, false);
 
   // empty indicates "not set" since roslaunch xml can't optionally set params
   auto hostname           = nh.param("sensor_hostname", std::string{});
@@ -328,7 +328,7 @@ int OusterNodelet::run() {
           imu_packet_pub.publish(imu_packet);
       }
       if (state == sensor::TIMEOUT) {
-        ROS_WARN("[OusterNodelet]: poll_client: TIMEOUT");
+        ROS_WARN("[OusterNodelet]: poll_client: TIMEOUT (check Ethernet connection)");
         std_msgs::String status_msg;
         status_msg.data = "-R Ouster TIMEOUT";
         alerts_publisher_uav_status_.publish(status_msg);

--- a/ouster_ros/src/os_nodelet.cpp
+++ b/ouster_ros/src/os_nodelet.cpp
@@ -354,13 +354,13 @@ int OusterNodelet::run_alerts_loop() {
       // republish all active alerts to rosconsole
       for (const auto& alert : active) {
         if (alert["level"].asString() == "ERROR") {
-          ROS_ERROR_THROTTLE(1.0, "[OusterNodelet] %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(),
+          ROS_ERROR("[OusterNodelet] %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(),
                              alert["msg"].asString().c_str());
         } else if (alert["level"].asString() == "WARNING") {
-          ROS_WARN_THROTTLE(1.0, "[OusterNodelet] %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(),
+          ROS_WARN("[OusterNodelet] %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(),
                             alert["msg"].asString().c_str());
         } else {
-          ROS_INFO_THROTTLE(1.0, "[OusterNodelet] %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(),
+          ROS_INFO("[OusterNodelet] %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(),
                             alert["msg"].asString().c_str());
         }
       }

--- a/ouster_ros/src/os_nodelet.cpp
+++ b/ouster_ros/src/os_nodelet.cpp
@@ -310,6 +310,10 @@ int OusterNodelet::run() {
         if (sensor::read_imu_packet(*cli, imu_packet.buf.data(), pf))
           imu_packet_pub.publish(imu_packet);
       }
+      if (state == sensor::TIMEOUT) {
+        ROS_WARN("[OusterNodelet]: poll_client: TIMEOUT");
+      }
+
 
     }
   }

--- a/ouster_ros/src/os_nodelet.cpp
+++ b/ouster_ros/src/os_nodelet.cpp
@@ -138,7 +138,7 @@ int OusterNodelet::run() {
   ROS_INFO("[OusterNodelet] Initialization started.");
 
   sensor_info_publisher_ = nh.advertise<mrs_msgs::OusterInfo>("sensor_info", 1, true);
-  alerts_publisher_ = nh.advertise<std_msgs::String>("alerts", 1, true);
+  alerts_publisher_      = nh.advertise<std_msgs::String>("alerts", 1, true);
 
   // empty indicates "not set" since roslaunch xml can't optionally set params
   auto hostname           = nh.param("sensor_hostname", std::string{});
@@ -348,29 +348,36 @@ int OusterNodelet::run_alerts_loop() {
 
     bool success = true;
     success &= reader->parse(alerts.c_str(), alerts.c_str() + alerts.size(), &root, NULL);
-    Json::Value active = root["active"];
 
-    // republish all active alerts to rosconsole
-    for (const auto& alert : active) {
-      if (alert["level"].asString() == "ERROR") {
-        ROS_ERROR_THROTTLE(1.0, "[OusterNodelet] %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(), alert["msg"].asString().c_str());
-      } else if (alert["level"].asString() == "WARNING") {
-        ROS_WARN_THROTTLE(1.0, "[OusterNodelet] %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(), alert["msg"].asString().c_str());
-      } else {
-        ROS_INFO_THROTTLE(1.0, "[OusterNodelet] %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(), alert["msg"].asString().c_str());
+    if (success) {
+      Json::Value active = root["active"];
+      // republish all active alerts to rosconsole
+      for (const auto& alert : active) {
+        if (alert["level"].asString() == "ERROR") {
+          ROS_ERROR_THROTTLE(1.0, "[OusterNodelet] %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(),
+                             alert["msg"].asString().c_str());
+        } else if (alert["level"].asString() == "WARNING") {
+          ROS_WARN_THROTTLE(1.0, "[OusterNodelet] %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(),
+                            alert["msg"].asString().c_str());
+        } else {
+          ROS_INFO_THROTTLE(1.0, "[OusterNodelet] %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(),
+                            alert["msg"].asString().c_str());
+        }
       }
-    }
 
-    Json::Value log = root["log"];
+      Json::Value log = root["log"];
 
-    for (const auto& alert : log) {
-      // publish a message if SHOT_LIMITING appeared in the log
-      if (alert["category"].asString() == "SHOT_LIMITING") {
-        ROS_WARN_ONCE("[OusterNodelet] Alert log contains: %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(), alert["msg"].asString().c_str());
-      }
-      // publish an error if some error appeared in the log
-      if (alert["level"].asString() == "ERROR") {
-        ROS_ERROR_ONCE("[OusterNodelet] Alert log contains: %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(), alert["msg"].asString().c_str());
+      for (const auto& alert : log) {
+        // publish a message if SHOT_LIMITING appeared in the log
+        if (alert["category"].asString() == "SHOT_LIMITING") {
+          ROS_WARN_ONCE("[OusterNodelet] Alert log contains: %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(),
+                        alert["msg"].asString().c_str());
+        }
+        // publish an error if some error appeared in the log
+        if (alert["level"].asString() == "ERROR") {
+          ROS_ERROR_ONCE("[OusterNodelet] Alert log contains: %s %s %s", alert["category"].asString().c_str(), alert["id"].asString().c_str(),
+                         alert["msg"].asString().c_str());
+        }
       }
     }
 


### PR DESCRIPTION
- Printing a warning when the client poll to the lidar device timeouts (e.g. when it physically disconnects)
- Obtaining diagnostic alerts from the lidar at the rate of 1 Hz, publishing them to rostopic, printing all currently active alerts to rosconsole, and printing a warning if an ERROR or SHOT_LIMITING appears in the alerts history
- Added `pixels_per_column`, `columns_per_frame` and `pixel_shift_by_row` to the OusterInfo message